### PR TITLE
Memory cells are now limited to only numbers between 0-255

### DIFF
--- a/interpreter/machine.go
+++ b/interpreter/machine.go
@@ -31,8 +31,14 @@ func (m *Machine) Execute() {
 		switch ins {
 		case '+':
 			m.memory[m.dp]++
+			if (m.memory[m.dp]==256) {
+				m.memory[m.dp]=0
+			}
 		case '-':
 			m.memory[m.dp]--
+			if (m.memory[m.dp]==-1) {
+				m.memory[m.dp]=255
+			}
 		case '>':
 			m.dp++
 		case '<':

--- a/virtualmachine/machine.go
+++ b/virtualmachine/machine.go
@@ -31,8 +31,14 @@ func (m *Machine) Execute() {
 		switch ins.Type {
 		case Plus:
 			m.memory[m.dp] += ins.Argument
+			if (m.memory[m.dp]==256) {
+				m.memory[m.dp]=0
+			}
 		case Minus:
 			m.memory[m.dp] -= ins.Argument
+			if (m.memory[m.dp]==-1) {
+				m.memory[m.dp]=255
+			}
 		case Right:
 			m.dp += ins.Argument
 		case Left:


### PR DESCRIPTION
I noticed that if a cell containing a '0' is subtracted, it becomes '-1'. This is incorrect behaviour, as brainfuck is supposed to run using unsigned 8 bit numbers. I implemented a fix for this.